### PR TITLE
feat: support go+ overload function

### DIFF
--- a/internal/godoc/parse_overload_func.go
+++ b/internal/godoc/parse_overload_func.go
@@ -1,0 +1,88 @@
+package godoc
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"go/ast"
+	"go/doc"
+	"strings"
+)
+
+// FindOverloadFuncThenAdd  Find overloaded functions and update function names
+func FindOverloadFuncThenAdd(p *Package) {
+	var overloadFuncName = make(map[string]string)
+	var overLoadFunc = make([]*ast.FuncDecl, 0)
+	for _, f := range p.encPackage.Files {
+		for _, decl := range f.AST.Decls {
+			// First it will traverse the constants
+			if g, ok := decl.(*ast.GenDecl); ok {
+				for _, specs := range g.Specs {
+					if vs, ok := specs.(*ast.ValueSpec); ok {
+						for _, name := range vs.Names {
+							if strings.Contains(name.Name, "Gopo_") {
+								for _, v := range vs.Values {
+									if bas, ok := v.(*ast.BasicLit); ok {
+										overloadFuncs := strings.Split(bas.Value, ",")
+										for i2 := range overloadFuncs {
+											overloadFuncName[strings.ReplaceAll(overloadFuncs[i2], "\"", "")] = strings.TrimPrefix(name.Name, "Gopo_")
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			// Secondly find the overloaded function and rename it
+			// Because the same function name will be filtered, a specific character set is required
+			if d, ok := decl.(*ast.FuncDecl); ok {
+				if k, ok := overloadFuncName[d.Name.Name]; ok {
+					name := fmt.Sprintf("%s!%s", k, uuid.NewString())
+					newFunc := &ast.FuncDecl{}
+					overLoadFunc = append(overLoadFunc, newFunc)
+					newFunc.Body = d.Body
+					newFunc.Doc = d.Doc
+					newFunc.Recv = d.Recv
+					newFunc.Type = d.Type
+					newFunc.Recv = d.Recv
+					newFunc.Type = d.Type
+					newFunc.Name = &ast.Ident{}
+					newFunc.Name.NamePos = d.Name.NamePos
+					newFunc.Name.Obj = d.Name.Obj
+					newFunc.Name.Name = name
+				}
+			}
+		}
+	}
+	for _, newFunc := range overLoadFunc {
+		for _, f := range p.encPackage.Files {
+			f.AST.Decls = append(f.AST.Decls, newFunc)
+		}
+	}
+}
+
+// RestoreFuncName Overloaded function restores function name
+func RestoreFuncName(funcs []*doc.Func) {
+	for _, f := range funcs {
+		f.Name = isOverloadFuncThenRestoresName(f.Name)
+	}
+}
+
+// RestoreFuncDeclName Overloaded function decl restores function name
+func RestoreFuncDeclName(funcs []*File) {
+	for _, f := range funcs {
+		for _, dec := range f.AST.Decls {
+			if fun, ok := dec.(*ast.FuncDecl); ok {
+				name := fun.Name.Name
+				fun.Name.Name = isOverloadFuncThenRestoresName(name)
+			}
+		}
+	}
+}
+
+func isOverloadFuncThenRestoresName(name string) string {
+	if strings.Contains(name, "!") {
+		return strings.SplitN(name, "!", 2)[0]
+	}
+	return name
+}

--- a/internal/godoc/parse_overload_func.go
+++ b/internal/godoc/parse_overload_func.go
@@ -3,6 +3,7 @@ package godoc
 import (
 	"go/ast"
 	"go/doc"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -38,6 +39,7 @@ func FindOverloadFuncThenAdd(d *doc.Package) {
 	}
 	var overloadFunc = make([]*doc.Func, 0)
 	for _, funcO := range d.Funcs {
+		RestoreName(funcO)
 		if name, ok := overloadFuncName[funcO.Name]; ok {
 			newFunc := &doc.Func{}
 			newFunc.Doc = funcO.Doc
@@ -57,4 +59,21 @@ func FindOverloadFuncThenAdd(d *doc.Package) {
 	sort.Slice(d.Funcs, func(i, j int) bool {
 		return d.Funcs[i].Name < d.Funcs[j].Name
 	})
+}
+
+// FindOverloadFuncThenRestoreName func name: xxx_001 xxx_002
+func FindOverloadFuncThenRestoreName(types []*doc.Type) {
+	for _, t := range types {
+		for _, f := range t.Funcs {
+			RestoreName(f)
+		}
+	}
+}
+
+// RestoreName restore overload func name
+func RestoreName(funcO *doc.Func) {
+	re := regexp.MustCompile(`__\d+`)
+	name := re.ReplaceAllString(funcO.Name, "")
+	funcO.Decl.Name.Name = name
+	funcO.Name = name
 }

--- a/internal/godoc/parse_overload_func.go
+++ b/internal/godoc/parse_overload_func.go
@@ -47,7 +47,8 @@ func FindOverloadFuncThenAdd(d *doc.Package) {
 			}
 		}
 	}
-	var overloadFunc = make([]*doc.Func, 0)
+	// even though overloadFuncName is empty, but the situation of funcName__N may occur, so it cannot be returned in advance
+	var overloadFunc = make([]*doc.Func, 0, len(overloadFuncName))
 	for _, funcO := range d.Funcs {
 		match, err := isMatchName(funcO.Name)
 		if err != nil {

--- a/internal/godoc/parse_overload_func.go
+++ b/internal/godoc/parse_overload_func.go
@@ -45,7 +45,7 @@ func FindOverloadFuncThenAdd(d *doc.Package) {
 	}
 	var overloadFunc = make([]*doc.Func, 0)
 	for _, funcO := range d.Funcs {
-		RestoreName(funcO)
+		restoreName(funcO)
 		if name, ok := overloadFuncName[funcO.Name]; ok {
 			newFunc := buildNewFunc(funcO, name)
 			overloadFunc = append(overloadFunc, newFunc)
@@ -64,13 +64,13 @@ func FindOverloadFuncThenAdd(d *doc.Package) {
 func FindOverloadFuncThenRestoreName(types []*doc.Type) {
 	for _, t := range types {
 		for _, f := range t.Funcs {
-			RestoreName(f)
+			restoreName(f)
 		}
 	}
 }
 
-// RestoreName restore overload func name
-func RestoreName(funcO *doc.Func) {
+// restoreName restore overload func name
+func restoreName(funcO *doc.Func) {
 	re := regexp.MustCompile(`__\d+`)
 	name := re.ReplaceAllString(funcO.Name, "")
 	funcO.Decl.Name.Name = name

--- a/internal/godoc/parse_overload_func.go
+++ b/internal/godoc/parse_overload_func.go
@@ -16,11 +16,12 @@ func FindOverloadFuncThenAdd(d *doc.Package) {
 					if vs, ok := spec.(*ast.ValueSpec); ok {
 						for _, name := range vs.Names {
 							if strings.Contains(name.Name, "Gopo_") {
+								n := strings.TrimPrefix(name.Name, "Gopo_")
 								for _, v := range vs.Values {
 									if bas, ok := v.(*ast.BasicLit); ok {
 										overloadFuncs := strings.Split(bas.Value, ",")
 										for i2 := range overloadFuncs {
-											overloadFuncName[strings.ReplaceAll(overloadFuncs[i2], "\"", "")] = strings.TrimPrefix(name.Name, "Gopo_")
+											overloadFuncName[strings.ReplaceAll(overloadFuncs[i2], "\"", "")] = n
 										}
 									}
 								}

--- a/internal/godoc/render.go
+++ b/internal/godoc/render.go
@@ -119,14 +119,11 @@ func (p *Package) DocPackage(innerPath string, modInfo *ModuleInfo) (_ *doc.Pack
 		}
 	}
 
-	FindOverloadFuncThenAdd(p)
-
 	d, err := doc.NewFromFiles(p.Fset, allGoFiles, importPath, m)
 	if err != nil {
 		return nil, fmt.Errorf("doc.NewFromFiles: %v", err)
 	}
-
-	RestoreFuncName(d.Funcs)
+	FindOverloadFuncThenAdd(d)
 
 	if d.ImportPath != importPath {
 		panic(fmt.Errorf("internal error: *doc.Package has an unexpected import path (%q != %q)", d.ImportPath, importPath))
@@ -230,7 +227,6 @@ func (p *Package) Render(ctx context.Context, innerPath string,
 	if err != nil {
 		return nil, err
 	}
-	RestoreFuncDeclName(p.encPackage.Files)
 
 	opts := p.renderOptions(innerPath, sourceInfo, modInfo, nameToVersion, bc)
 	parts, err := dochtml.Render(ctx, p.Fset, d, opts)

--- a/internal/godoc/render.go
+++ b/internal/godoc/render.go
@@ -124,7 +124,7 @@ func (p *Package) DocPackage(innerPath string, modInfo *ModuleInfo) (_ *doc.Pack
 		return nil, fmt.Errorf("doc.NewFromFiles: %v", err)
 	}
 	FindOverloadFuncThenAdd(d)
-	FindOverloadFuncThenRestoreName(d.Types)
+	FindOverloadFuncTypeThenRestoreName(d.Types)
 	if d.ImportPath != importPath {
 		panic(fmt.Errorf("internal error: *doc.Package has an unexpected import path (%q != %q)", d.ImportPath, importPath))
 	}

--- a/internal/godoc/render.go
+++ b/internal/godoc/render.go
@@ -124,7 +124,7 @@ func (p *Package) DocPackage(innerPath string, modInfo *ModuleInfo) (_ *doc.Pack
 		return nil, fmt.Errorf("doc.NewFromFiles: %v", err)
 	}
 	FindOverloadFuncThenAdd(d)
-
+	FindOverloadFuncThenRestoreName(d.Types)
 	if d.ImportPath != importPath {
 		panic(fmt.Errorf("internal error: *doc.Package has an unexpected import path (%q != %q)", d.ImportPath, importPath))
 	}

--- a/internal/godoc/render.go
+++ b/internal/godoc/render.go
@@ -114,12 +114,19 @@ func (p *Package) DocPackage(innerPath string, modInfo *ModuleInfo) (_ *doc.Pack
 	}
 	var allGoFiles []*ast.File
 	for _, f := range p.Files {
-		allGoFiles = append(allGoFiles, f.AST)
+		if f.Name != "" {
+			allGoFiles = append(allGoFiles, f.AST)
+		}
 	}
+
+	FindOverloadFuncThenAdd(p)
+
 	d, err := doc.NewFromFiles(p.Fset, allGoFiles, importPath, m)
 	if err != nil {
 		return nil, fmt.Errorf("doc.NewFromFiles: %v", err)
 	}
+
+	RestoreFuncName(d.Funcs)
 
 	if d.ImportPath != importPath {
 		panic(fmt.Errorf("internal error: *doc.Package has an unexpected import path (%q != %q)", d.ImportPath, importPath))
@@ -223,6 +230,7 @@ func (p *Package) Render(ctx context.Context, innerPath string,
 	if err != nil {
 		return nil, err
 	}
+	RestoreFuncDeclName(p.encPackage.Files)
 
 	opts := p.renderOptions(innerPath, sourceInfo, modInfo, nameToVersion, bc)
 	parts, err := dochtml.Render(ctx, p.Fset, d, opts)


### PR DESCRIPTION
# 需求：
- 显示重载函数。例如: AddInit，AddFloat，重载函数名为:Add，则需要新增2个名为Add函数
- 修复跳转源文件问题

# 实现思路
## 显示重载函数
> render#125 ：d, err := doc.NewFromFiles(p.Fset, allGoFiles, importPath, m) 

这一步会过滤重复函数名，因此在此之前新增的的函数添加特定字符集，执行后还原函数名

## 跳转源文件问题
> pkgsite在解析偏移量时计算错误

遇到go+文件则计算文件名即可

# 问题
> middleware#28：ctx, cancel := context.WithCancelCause(r.Context())  WithCancelCause **not found**
经排查，WithCancelCause 属于go v1.20+产物，而pkgsite go.mod version：1.19
